### PR TITLE
feat: walk fs for projects

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -32,6 +32,10 @@ pub fn openConfig(arena: Allocator, env_map: *const process.EnvMap) !ConfigConte
     var path_buf: [fs.max_path_bytes]u8 = undefined;
     const config_path = try getConfigPath(&path_buf, env_map);
 
+    return getConfigContext(arena, config_path);
+}
+
+fn getConfigContext(arena: Allocator, config_path: []const u8) !ConfigContext {
     var config_dir = try fs.cwd().makeOpenPath(config_path, .{});
     defer config_dir.close();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -141,11 +141,14 @@ fn search(arena: Allocator, search_opts: cli.SearchOpts) !void {
     }
 
     const walk = @import("walk.zig");
-    for (cfg.project_roots) |root| {
-        std.debug.print("searching {s}...\n", .{root});
-        try walk.search(arena, root);
-        std.debug.print("\n", .{});
-    }
+
+    var buf: [2048]u8 = undefined;
+    var stdout_bw = fs.File.stdout().writer(&buf);
+    const stdout = &stdout_bw.interface;
+
+    const count = try walk.scanProjects(arena, cfg.project_roots, .{ .writer = stdout });
+    try stdout.print("found {d} projects\n", .{count});
+    try stdout.flush();
 }
 
 test "ref all decls" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -139,6 +139,13 @@ fn search(arena: Allocator, search_opts: cli.SearchOpts) !void {
         try fs.File.stderr().writeAll("no project roots found. add one using the '--add-paths' flag");
         process.exit(1);
     }
+
+    const walk = @import("walk.zig");
+    for (cfg.project_roots) |root| {
+        std.debug.print("searching {s}...\n", .{root});
+        try walk.search(arena, root);
+        std.debug.print("\n", .{});
+    }
 }
 
 test "ref all decls" {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2,4 +2,5 @@ comptime {
     _ = @import("main.zig");
     _ = @import("cli.zig");
     _ = @import("config.zig");
+    _ = @import("walk.zig");
 }

--- a/src/walk.zig
+++ b/src/walk.zig
@@ -2,20 +2,95 @@ const std = @import("std");
 const fs = std.fs;
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
+const Writer = std.Io.Writer;
 
-// TODO: do we want to accept this as an argument? or have it per path?
-const max_depth = 5;
+const default_project_markers: []const []const u8 = &.{ ".git", ".jj" };
+
+/// when to flush the writer
+pub const FlushAfter = enum {
+    /// never flush
+    never,
+    /// only flush at the end of the search
+    end,
+    /// flush after checking each root path
+    root,
+    /// flush after appending a project
+    project,
+};
+
+pub const ScanOpts = struct {
+    /// writer to report to
+    writer: *Writer,
+    /// when to flush the writer
+    flush_after: FlushAfter = .root,
+    /// max depth for searching for projects
+    max_depth: usize = 5,
+    /// marker to identify if a project exists
+    project_markers: []const []const u8 = default_project_markers,
+    /// byte for separating projects in writer
+    separator_byte: u8 = '\n',
+};
+
+pub const SearchOpts = struct {
+    /// optional writer to report to
+    writer: ?*Writer = null,
+    /// when to flush the writer (if it exists)
+    flush_after: FlushAfter = .never,
+    /// max depth for searching for projects
+    max_depth: usize = 5,
+    /// marker to identify if a project exists
+    project_markers: []const []const u8 = default_project_markers,
+    /// byte for separating projects in writer
+    separator_byte: u8 = '\n',
+};
+
+const ContextOptions = union(enum) {
+    search_opts: SearchOpts,
+    scan_opts: ScanOpts,
+};
 
 const Context = struct {
-    // TODO: change to set
-    projects: ArrayList([]const u8) = .empty,
+    projects: std.StringArrayHashMapUnmanaged(void) = .empty,
     path_stack: ArrayList([]const u8) = .empty,
+    /// the check stack never owns the strings
     to_check_stack: ArrayList([]const u8) = .empty,
 
-    fn init(gpa: Allocator, root_path: []const u8) !Context {
-        var ctx: Context = .{};
+    // config
+    max_depth: usize,
+    project_markers: []const []const u8,
+    writer: ?*Writer,
+    flush_after: FlushAfter,
+    separator_byte: u8,
+
+    fn init(ctx_opts: ContextOptions) Context {
+        return switch (ctx_opts) {
+            inline else => |opts| .{
+                .max_depth = opts.max_depth,
+                .writer = opts.writer,
+                .project_markers = opts.project_markers,
+                .flush_after = opts.flush_after,
+                .separator_byte = opts.separator_byte,
+            },
+        };
+    }
+
+    fn initWithRoot(gpa: Allocator, root_path: []const u8, opts: ContextOptions) !Context {
+        var ctx: Context = .init(opts);
         try ctx.path_stack.append(gpa, root_path);
+
         return ctx;
+    }
+
+    fn changeRoot(self: *Context, gpa: Allocator, root_path: []const u8) !void {
+        // items in this stack are never owned
+        self.path_stack.clearRetainingCapacity();
+
+        for (self.to_check_stack.items) |field| {
+            gpa.free(field);
+        }
+        self.to_check_stack.clearRetainingCapacity();
+
+        try self.path_stack.append(gpa, root_path);
     }
 
     fn popToCheck(self: *Context, gpa: Allocator, items_to_pop: usize) void {
@@ -34,40 +109,86 @@ const Context = struct {
         }
         self.to_check_stack.deinit(gpa);
 
-        for (self.projects.items) |field| {
-            gpa.free(field);
+        for (self.projects.keys()) |key| {
+            gpa.free(key);
         }
         self.projects.deinit(gpa);
     }
 };
 
-// TODO:
-// - change to accept writer (would allow to write to FZF immediately)
-//   - would need to check the project set before writing
-// - accept multiple root_paths
-pub fn search(gpa: Allocator, root_path: []const u8) !void {
-    var root_dir = try fs.openDirAbsolute(root_path, .{ .iterate = true });
-    defer root_dir.close();
+/// scan for projects and write their full path to provided writer.
+/// return number of projects found
+pub fn scanProjects(gpa: Allocator, root_paths: []const []const u8, opts: ScanOpts) !usize {
+    var ctx = try search(gpa, root_paths, .{ .scan_opts = opts });
+    defer ctx.deinit(gpa);
 
-    var ctx: Context = try .init(gpa, root_path);
+    return ctx.projects.count();
+}
 
-    try searchDir(gpa, &ctx, root_dir, 0);
+/// search for projects and return their full path as a set.
+/// if no arena is used, caller must free the return object. check `freeProjects`
+pub fn searchProjects(gpa: Allocator, root_paths: []const []const u8, opts: SearchOpts) !std.StringArrayHashMapUnmanaged(void) {
+    var ctx = try search(gpa, root_paths, .{ .search_opts = opts });
+    defer ctx.deinit(gpa);
 
-    for (ctx.projects.items) |proj| {
-        std.debug.print("found {s}\n", .{proj});
+    return ctx.projects.move();
+}
+
+/// frees the projects by freeing the keys and de-initing the backing map
+pub fn freeProjects(gpa: Allocator, projects: *std.StringArrayHashMapUnmanaged(void)) void {
+    for (projects.keys()) |proj| {
+        gpa.free(proj);
     }
+    projects.deinit(gpa);
+}
+
+fn search(gpa: Allocator, root_paths: []const []const u8, opts: ContextOptions) !Context {
+    var ctx: Context = .init(opts);
+
+    for (root_paths) |root_path| {
+        try ctx.changeRoot(gpa, root_path);
+
+        var root_dir = try fs.openDirAbsolute(root_path, .{ .iterate = true });
+        defer root_dir.close();
+
+        try searchDir(gpa, &ctx, root_dir, 0);
+
+        if (ctx.flush_after == .root) {
+            if (ctx.writer) |w| try w.flush();
+        }
+    }
+
+    if (ctx.flush_after == .end) {
+        if (ctx.writer) |w| try w.flush();
+    }
+
+    return ctx;
 }
 
 fn searchDir(gpa: Allocator, ctx: *Context, dir: fs.Dir, depth: usize) !void {
-    if (depth > max_depth) return;
+    if (depth > ctx.max_depth) return;
 
     const to_check_start_idx = ctx.to_check_stack.items.len;
 
     var iter = dir.iterate();
     while (try iter.next()) |inner| {
-        if (std.mem.eql(u8, inner.name, ".git")) {
+        if (anyEql(ctx.project_markers, inner.name)) {
             const path_name = try fs.path.join(gpa, ctx.path_stack.items);
-            try ctx.projects.append(gpa, path_name);
+
+            const gop = try ctx.projects.getOrPut(gpa, path_name);
+
+            // a key was already allocated, this one needs to be freed
+            if (gop.found_existing) {
+                gpa.free(path_name);
+            } else {
+                if (ctx.writer) |w| {
+                    try w.writeAll(path_name);
+                    try w.writeByte(ctx.separator_byte);
+
+                    if (ctx.flush_after == .project) try w.flush();
+                }
+            }
+
             ctx.popToCheck(gpa, ctx.to_check_stack.items.len - to_check_start_idx);
             return;
         }
@@ -90,6 +211,13 @@ fn searchDir(gpa: Allocator, ctx: *Context, dir: fs.Dir, depth: usize) !void {
 
         try searchDir(gpa, ctx, dir_to_check, depth + 1);
     }
+}
+
+fn anyEql(haystack: []const []const u8, needle: []const u8) bool {
+    for (haystack) |str| {
+        if (std.mem.eql(u8, str, needle)) return true;
+    }
+    return false;
 }
 
 test "ref all decls" {

--- a/src/walk.zig
+++ b/src/walk.zig
@@ -1,0 +1,97 @@
+const std = @import("std");
+const fs = std.fs;
+const Allocator = std.mem.Allocator;
+const ArrayList = std.ArrayList;
+
+// TODO: do we want to accept this as an argument? or have it per path?
+const max_depth = 5;
+
+const Context = struct {
+    // TODO: change to set
+    projects: ArrayList([]const u8) = .empty,
+    path_stack: ArrayList([]const u8) = .empty,
+    to_check_stack: ArrayList([]const u8) = .empty,
+
+    fn init(gpa: Allocator, root_path: []const u8) !Context {
+        var ctx: Context = .{};
+        try ctx.path_stack.append(gpa, root_path);
+        return ctx;
+    }
+
+    fn popToCheck(self: *Context, gpa: Allocator, items_to_pop: usize) void {
+        for (0..items_to_pop) |_| {
+            const field = self.to_check_stack.pop() orelse return;
+            gpa.free(field);
+        }
+    }
+
+    fn deinit(self: *Context, gpa: Allocator) void {
+        // items in this stack are never owned
+        self.path_stack.deinit(gpa);
+
+        for (self.to_check_stack.items) |field| {
+            gpa.free(field);
+        }
+        self.to_check_stack.deinit(gpa);
+
+        for (self.projects.items) |field| {
+            gpa.free(field);
+        }
+        self.projects.deinit(gpa);
+    }
+};
+
+// TODO:
+// - change to accept writer (would allow to write to FZF immediately)
+//   - would need to check the project set before writing
+// - accept multiple root_paths
+pub fn search(gpa: Allocator, root_path: []const u8) !void {
+    var root_dir = try fs.openDirAbsolute(root_path, .{ .iterate = true });
+    defer root_dir.close();
+
+    var ctx: Context = try .init(gpa, root_path);
+
+    try searchDir(gpa, &ctx, root_dir, 0);
+
+    for (ctx.projects.items) |proj| {
+        std.debug.print("found {s}\n", .{proj});
+    }
+}
+
+fn searchDir(gpa: Allocator, ctx: *Context, dir: fs.Dir, depth: usize) !void {
+    if (depth > max_depth) return;
+
+    const to_check_start_idx = ctx.to_check_stack.items.len;
+
+    var iter = dir.iterate();
+    while (try iter.next()) |inner| {
+        if (std.mem.eql(u8, inner.name, ".git")) {
+            const path_name = try fs.path.join(gpa, ctx.path_stack.items);
+            try ctx.projects.append(gpa, path_name);
+            ctx.popToCheck(gpa, ctx.to_check_stack.items.len - to_check_start_idx);
+            return;
+        }
+
+        if (inner.kind != .directory) continue;
+        try ctx.to_check_stack.append(gpa, try gpa.dupe(u8, inner.name));
+    }
+
+    const end_idx = ctx.to_check_stack.items.len;
+    defer ctx.popToCheck(gpa, end_idx - to_check_start_idx);
+
+    for (to_check_start_idx..end_idx) |idx| {
+        const to_check = ctx.to_check_stack.items[idx];
+
+        try ctx.path_stack.append(gpa, to_check);
+        defer _ = ctx.path_stack.pop();
+
+        var dir_to_check = try dir.openDir(to_check, .{ .iterate = true });
+        defer dir_to_check.close();
+
+        try searchDir(gpa, ctx, dir_to_check, depth + 1);
+    }
+}
+
+test "ref all decls" {
+    std.testing.refAllDeclsRecursive(@This());
+}

--- a/test/walk-tree.json
+++ b/test/walk-tree.json
@@ -1,0 +1,174 @@
+[
+  {
+    "name": "root-1",
+    "type": "directory",
+    "children": [
+      {
+        "name": "a-file.txt",
+        "type": "file"
+      },
+      {
+        "name": "nest-1-1",
+        "type": "directory",
+        "children": [
+          {
+            "name": "not-proj-1-1-1",
+            "type": "directory",
+            "children": [
+              {
+                "name": "documents.csv",
+                "type": "file"
+              }
+            ]
+          },
+          {
+            "name": "proj-1-1-1",
+            "type": "directory",
+            "children": [
+              {
+                "name": ".git",
+                "type": "directory",
+                "children": []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "not-proj-1-1",
+        "type": "directory",
+        "children": [
+          {
+            "name": "empty",
+            "type": "directory",
+            "children": [
+              {
+                "name": "emptier",
+                "type": "directory",
+                "children": [
+                  {
+                    "name": "foo.txt",
+                    "type": "file"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "proj-1-1",
+        "type": "directory",
+        "children": [
+          {
+            "name": ".abc",
+            "type": "file"
+          },
+          {
+            "name": ".git",
+            "type": "directory",
+            "children": []
+          },
+          {
+            "name": "text.txt",
+            "type": "file"
+          }
+        ]
+      },
+      {
+        "name": "proj-1-2",
+        "type": "directory",
+        "children": [
+          {
+            "name": ".jj",
+            "type": "directory",
+            "children": []
+          },
+          {
+            "name": "README.md",
+            "type": "file"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "root-2",
+    "type": "directory",
+    "children": [
+      {
+        "name": "proj-2-1",
+        "type": "directory",
+        "children": [
+          {
+            "name": ".jj",
+            "type": "file"
+          },
+          {
+            "name": "src",
+            "type": "directory",
+            "children": [
+              {
+                "name": "main.c",
+                "type": "file"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "root-3",
+    "type": "directory",
+    "children": [
+      {
+        "name": ".git",
+        "type": "directory",
+        "children": []
+      },
+      {
+        "name": "ziglab",
+        "type": "directory",
+        "children": [
+          {
+            "name": ".git",
+            "type": "file"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "root-4",
+    "type": "directory",
+    "children": [
+      {
+        "name": "bar",
+        "type": "directory",
+        "children": [
+          {
+            "name": "baz",
+            "type": "directory",
+            "children": [
+              {
+                "name": "b.txt",
+                "type": "file"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "foo",
+        "type": "directory",
+        "children": [
+          {
+            "name": "a.txt",
+            "type": "file"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## TODO

- [x] set instead of list for projects
- [x] accept writing to a writer or returning a list
- [ ] pull into own lib
- [x] accept list of paths (reset ctx lists while re-using allocated mem)
- [x] tests

### Unrelated TODO

- [x] change config module to separate getting file name and opening config (for tests)