### PR TITLE
feat: change fzf behaviour to blocking

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -22,21 +22,6 @@ pub fn build(b: *std.Build) !void {
     const version = try std.SemanticVersion.parse(build_zig_zon.version);
     options.addOption(std.SemanticVersion, "cs_version", version);
 
-    const flush_flag = "fzf-flush-after";
-
-    const fzf_flush_after = b.option(
-        walk.FlushAfter,
-        flush_flag,
-        "Determine when to flush the projects found to fzf",
-    ) orelse .root;
-
-    if (fzf_flush_after == .never) {
-        std.log.err("Cannot pass 'never' to {s}", .{flush_flag});
-        std.process.exit(1);
-    }
-
-    options.addOption(walk.FlushAfter, "fzf_flush_after", fzf_flush_after);
-
     const mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,


### PR DESCRIPTION
experimental branch for different fzf behaviour

pros:
- simplifies logic
- doesn't have the issue of selecting something and still needing to wait (because walker will keep reading until it writes to fzf, and only stops when it fails)
- all info appears at once, can be a bit cleaner
- no 'flashing' fzf screen when searching for specific project and it eventually finds it

cons:
- slower, since it only spawns fzf after finding all projects

after the async IO implementation, with proper cancelation for the runner, actual full async could be implemented